### PR TITLE
[ FIX ] slackthread

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "overlay-express-examples",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "overlay-express-examples",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Open BSV",
       "dependencies": {
         "@bsv/overlay": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overlay-express-examples",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Run the overlay infrastructure for distributed applications.",
   "homepage": "https://github.com/bsv-blockchain/overlay-express-examples#readme",
   "bugs": {

--- a/src/services/slackthreads/SlackThreadsLookupServiceDocs.md.ts
+++ b/src/services/slackthreads/SlackThreadsLookupServiceDocs.md.ts
@@ -1,7 +1,7 @@
 export default `
 # SlackThread Lookup Service Documentation
 
-The **SlackThread Lookup Service** (service ID: \`ls_slackthreads\`) lets clients search the on-chain *SlackThread* messages that are indexed by the **SlackThread Topic Manager**. Each record represents a Pay-to-Push-Drop output whose single field is a UTF-8 message of at least two characters.
+The **SlackThread Lookup Service** (service ID: \`ls_slackthread\`) lets clients search the on-chain *SlackThread* messages that are indexed by the **SlackThread Topic Manager**. Each record represents a Pay-to-Push-Drop output whose single field is a UTF-8 message of at least two characters.
 
 ## Example
 \`\`\`typescript
@@ -9,10 +9,25 @@ import { LookupResolver } from '@bsv/sdk'
 
 const overlay = new LookupResolver()
 
+// find all
+const response2 = await overlay.query({ 
+    service: 'ls_slackthread', 
+    query: {} 
+}, 10000)
+
+// find by thread hash
 const response = await overlay.query({ 
-    service: 'ls_slackthreads', 
+    service: 'ls_slackthread', 
     query: {
         threadHash: 'some 32 byte hash of a thread'
+    } 
+}, 10000)
+
+// find by txid
+const response3 = await overlay.query({ 
+    service: 'ls_slackthread', 
+    query: {
+        txid: 'some txid'
     } 
 }, 10000)
 \`\`\`

--- a/src/services/slackthreads/SlackThreadsLookupServiceFactory.ts
+++ b/src/services/slackthreads/SlackThreadsLookupServiceFactory.ts
@@ -44,7 +44,7 @@ export class SlackThreadLookupService implements LookupService {
 
     try {
       const threadHash = lockingScript.chunks[1].data
-      if (threadHash.length !== 32) throw new Error('Invalid SlackThread token: thread hash too short')
+      if (threadHash.length !== 32) throw new Error('Invalid SlackThread token: thread hash must be exactly 32 bytes')
       const threadHashString = Utils.toHex(threadHash)
 
       // Persist for future lookup

--- a/src/services/slackthreads/SlackThreadsStorage.ts
+++ b/src/services/slackthreads/SlackThreadsStorage.ts
@@ -11,6 +11,14 @@ export class SlackThreadsStorage {
    */
   constructor(private readonly db: Db) {
     this.records = db.collection<SlackThreadRecord>('slackThreadRecords')
+    this.createSearchableIndex() // Initialize the searchable index
+  }
+
+  /* Ensures a text index exists for the `threadHash` field, enabling efficient searches.
+   * The index is named `threadHashIndex`.
+   */
+  private async createSearchableIndex(): Promise<void> {
+    await this.records.createIndex({ threadHash: 1 }, { name: 'threadHashIndex' })
   }
 
   /**
@@ -61,6 +69,42 @@ export class SlackThreadsStorage {
     return this.records
       .find(
         { threadHash },
+        { projection: { txid: 1, outputIndex: 1, createdAt: 1 } }
+      )
+      .sort({ createdAt: direction })
+      .skip(skip)
+      .limit(limit)
+      .toArray()
+      .then(results =>
+        results.map(r => ({
+          txid: r.txid,
+          outputIndex: r.outputIndex
+        }))
+      )
+  }
+
+  /**
+   * Finds SlackThread records containing the specified thread hash (case-insensitive).
+   *
+   * @param threadHash       Partial or full thread hash to search for
+   * @param limit         Max number of results to return (default = 50)
+   * @param skip          Number of results to skip for pagination (default = 0)
+   * @param sortOrder     'asc' | 'desc' – sort by createdAt (default = 'desc')
+   */
+  async findByTxid(
+    txid: string,
+    limit: number = 50,
+    skip: number = 0,
+    sortOrder: 'asc' | 'desc' = 'desc'
+  ): Promise<UTXOReference[]> {
+    if (!txid) return []
+
+    // Map text value → numeric MongoDB sort direction
+    const direction = sortOrder === 'asc' ? 1 : -1
+
+    return this.records
+      .find(
+        { txid },
         { projection: { txid: 1, outputIndex: 1, createdAt: 1 } }
       )
       .sort({ createdAt: direction })

--- a/src/services/slackthreads/SlackThreadsStorage.ts
+++ b/src/services/slackthreads/SlackThreadsStorage.ts
@@ -84,9 +84,9 @@ export class SlackThreadsStorage {
   }
 
   /**
-   * Finds SlackThread records containing the specified thread hash (case-insensitive).
+   * Finds SlackThread records containing the specified transaction ID (case-insensitive).
    *
-   * @param threadHash       Partial or full thread hash to search for
+   * @param txid            Partial or full transaction ID to search for
    * @param limit         Max number of results to return (default = 50)
    * @param skip          Number of results to skip for pagination (default = 0)
    * @param sortOrder     'asc' | 'desc' – sort by createdAt (default = 'desc')

--- a/src/services/slackthreads/SlackThreadsTopicDocs.ts
+++ b/src/services/slackthreads/SlackThreadsTopicDocs.ts
@@ -1,7 +1,7 @@
 export default `
 # SlackThread Topic Manager Documentation
 
-The **SlackThread Topic Manager** (topic ID: \`tm_slackthreads\`) lets clients Push hashes to chain and remove them by revealing the preimage.
+The **SlackThread Topic Manager** (topic ID: \`tm_slackthread\`) lets clients Push hashes to chain and remove them by revealing the preimage.
 
 Either there is a locking script of the form:
 


### PR DESCRIPTION
The topic manager was checking for a different token type when compared to the lookup service so even tokens which were valid for one were invalid for the other. This PR consolidates that discrepency.