### PR TITLE
Desktop integrity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "overlay-express-examples",
-  "version": "2.1.2",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "overlay-express-examples",
-      "version": "2.1.2",
+      "version": "2.1.5",
       "license": "Open BSV",
       "dependencies": {
         "@bsv/overlay": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "overlay-express-examples",
-  "version": "2.1.2",
+  "version": "2.1.5",
   "description": "Run the overlay infrastructure for distributed applications.",
   "homepage": "https://github.com/bsv-blockchain/overlay-express-examples#readme",
   "bugs": {

--- a/src/services/desktopintegrity/DesktopIntegrityLookupServiceFactory.ts
+++ b/src/services/desktopintegrity/DesktopIntegrityLookupServiceFactory.ts
@@ -39,7 +39,7 @@ export class DesktopIntegrityLookupService implements LookupService {
    */
   async outputAdmittedByTopic(payload: OutputAdmittedByTopic): Promise<void> {
     if (payload.mode !== 'locking-script') throw new Error('Invalid mode')
-    const { topic, lockingScript, txid, outputIndex, offChainValues } = payload
+    const { topic, lockingScript, txid, outputIndex } = payload
     if (topic !== 'tm_desktopintegrity') return
 
     try {
@@ -48,7 +48,7 @@ export class DesktopIntegrityLookupService implements LookupService {
       const fileHashString = Utils.toHex(fileHash.slice(1))
 
       // Persist for future lookup
-      await this.storage.storeRecord(txid, outputIndex, fileHashString, offChainValues)
+      await this.storage.storeRecord(txid, outputIndex, fileHashString)
     } catch (err) {
       console.error(`DesktopIntegrityLookupService: failed to index ${txid}.${outputIndex}`, err)
     }

--- a/src/services/desktopintegrity/DesktopIntegrityStorage.ts
+++ b/src/services/desktopintegrity/DesktopIntegrityStorage.ts
@@ -34,7 +34,7 @@ export class DesktopIntegrityStorage {
       txid,
       outputIndex,
       fileHash,
-      offChainValues,
+      offChainValues: Buffer.from(offChainValues),
       createdAt: new Date()
     })
   }
@@ -76,9 +76,9 @@ export class DesktopIntegrityStorage {
       .sort({ createdAt: direction })
       .skip(skip)
       .limit(limit)
-      .project<{ txid: string; outputIndex: number; offChainValues: number[] }>({ txid: 1, outputIndex: 1, offChainValues: 1 })
+      .project<{ txid: string; outputIndex: number; offChainValues: { buffer: Buffer } | null }>({ txid: 1, outputIndex: 1, offChainValues: 1 })
       .toArray()
-    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex, context: r.offChainValues }))
+    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex, context: r.offChainValues ? Array.from(r.offChainValues.buffer) : undefined }))
   }
 
   /**
@@ -108,9 +108,9 @@ export class DesktopIntegrityStorage {
       .sort({ createdAt: direction })
       .skip(skip)
       .limit(limit)
-      .project<{ txid: string; outputIndex: number; offChainValues: number[] }>({ txid: 1, outputIndex: 1, offChainValues: 1 })
+      .project<{ txid: string; outputIndex: number; offChainValues: { buffer: Buffer } | null }>({ txid: 1, outputIndex: 1, offChainValues: 1 })
       .toArray()
-    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex, context: r.offChainValues }))
+    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex, context: r.offChainValues ? Array.from(r.offChainValues.buffer) : undefined }))
   }
 
   /**
@@ -142,9 +142,9 @@ export class DesktopIntegrityStorage {
       .sort({ createdAt: sortDirection })
       .skip(skip)
       .limit(limit)
-      .project<{ txid: string; outputIndex: number; offChainValues: number[] }>({ txid: 1, outputIndex: 1, offChainValues: 1 })
+      .project<{ txid: string; outputIndex: number; offChainValues: { buffer: Buffer } | null }>({ txid: 1, outputIndex: 1, offChainValues: 1 })
       .toArray()
-    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex, context: r.offChainValues }))
+    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex, context: r.offChainValues ? Array.from(r.offChainValues.buffer) : undefined }))
   }
 
   // Additional custom query functions can be added here. ---------------------------------------------

--- a/src/services/desktopintegrity/DesktopIntegrityStorage.ts
+++ b/src/services/desktopintegrity/DesktopIntegrityStorage.ts
@@ -26,15 +26,13 @@ export class DesktopIntegrityStorage {
    * @param {string} txid - The transaction ID associated with this record
    * @param {number} outputIndex - The UTXO output index
    * @param {string} fileHash - The file hash to be stored
-   * @param {number[]} offChainValues - The off-chain values to be stored
    * @returns {Promise<void>} - Resolves when the record has been successfully stored
    */
-  async storeRecord(txid: string, outputIndex: number, fileHash: string, offChainValues: number[]): Promise<void> {
+  async storeRecord(txid: string, outputIndex: number, fileHash: string): Promise<void> {
     await this.records.insertOne({
       txid,
       outputIndex,
       fileHash,
-      offChainValues: Buffer.from(offChainValues),
       createdAt: new Date()
     })
   }
@@ -69,16 +67,13 @@ export class DesktopIntegrityStorage {
     const direction = sortOrder === 'asc' ? 1 : -1
 
     const results = await this.records
-      .find(
-        { fileHash },
-        { projection: { txid: 1, outputIndex: 1, offChainValues: 1, createdAt: 1 } }
-      )
+      .find({ fileHash })
       .sort({ createdAt: direction })
       .skip(skip)
       .limit(limit)
-      .project<{ txid: string; outputIndex: number; offChainValues: { buffer: Buffer } | null }>({ txid: 1, outputIndex: 1, offChainValues: 1 })
+      .project<{ txid: string; outputIndex: number }>({ txid: 1, outputIndex: 1 })
       .toArray()
-    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex, context: r.offChainValues ? Array.from(r.offChainValues.buffer) : undefined }))
+    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex }))
   }
 
   /**
@@ -101,16 +96,13 @@ export class DesktopIntegrityStorage {
     const direction = sortOrder === 'asc' ? 1 : -1
 
     const results = await this.records
-      .find(
-        { txid },
-        { projection: { txid: 1, outputIndex: 1, offChainValues: 1, createdAt: 1 } }
-      )
+      .find({ txid })
       .sort({ createdAt: direction })
       .skip(skip)
       .limit(limit)
-      .project<{ txid: string; outputIndex: number; offChainValues: { buffer: Buffer } | null }>({ txid: 1, outputIndex: 1, offChainValues: 1 })
+      .project<{ txid: string; outputIndex: number }>({ txid: 1, outputIndex: 1 })
       .toArray()
-    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex, context: r.offChainValues ? Array.from(r.offChainValues.buffer) : undefined }))
+    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex }))
   }
 
   /**
@@ -142,9 +134,9 @@ export class DesktopIntegrityStorage {
       .sort({ createdAt: sortDirection })
       .skip(skip)
       .limit(limit)
-      .project<{ txid: string; outputIndex: number; offChainValues: { buffer: Buffer } | null }>({ txid: 1, outputIndex: 1, offChainValues: 1 })
+      .project<{ txid: string; outputIndex: number }>({ txid: 1, outputIndex: 1 })
       .toArray()
-    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex, context: r.offChainValues ? Array.from(r.offChainValues.buffer) : undefined }))
+    return results.map(r => ({ txid: r.txid, outputIndex: r.outputIndex }))
   }
 
   // Additional custom query functions can be added here. ---------------------------------------------

--- a/src/services/desktopintegrity/types.ts
+++ b/src/services/desktopintegrity/types.ts
@@ -2,7 +2,7 @@ export interface DesktopIntegrityRecord {
   txid: string
   outputIndex: number
   fileHash: string
-  offChainValues: Array<number>
+  offChainValues: Buffer | null
   createdAt: Date
 }
 

--- a/src/services/desktopintegrity/types.ts
+++ b/src/services/desktopintegrity/types.ts
@@ -2,12 +2,10 @@ export interface DesktopIntegrityRecord {
   txid: string
   outputIndex: number
   fileHash: string
-  offChainValues: Buffer | null
   createdAt: Date
 }
 
 export interface UTXOReference {
   txid: string
   outputIndex: number
-  context?: number[]
 }

--- a/src/services/supplychain/SupplyChainTopicManager.ts
+++ b/src/services/supplychain/SupplyChainTopicManager.ts
@@ -51,10 +51,9 @@ export default class SupplyChainTopicManager implements TopicManager {
       }
     }
 
-    // The SupplyChain protocol never retains previous coins
     return {
       outputsToAdmit,
-      coinsToRetain: []
+      coinsToRetain: previousCoins
     }
   }
 

--- a/src/services/supplychain/types.ts
+++ b/src/services/supplychain/types.ts
@@ -8,4 +8,5 @@ export interface SupplyChainRecord {
 export interface UTXOReference {
   txid: string
   outputIndex: number
+  spendingTxid?: string
 }


### PR DESCRIPTION
Mongodb stores number arrays differently resulting in a size bloat, binary files like docx were reaching size limits, Buffer should fix this issue.